### PR TITLE
Fix version_added of `isIntersecting`

### DIFF
--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -250,10 +250,10 @@
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverentry-isintersecting",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": "58"
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": "58"
             },
             "edge": {
               "version_added": "16"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Actually, `IntersectionObserverEntry.isIntersecting` was added after Chrome/58

See: <https://github.com/Fyrd/caniuse/blob/main/features-json/intersectionobserver.json#L222>

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

I only test this feature on Chrome/55

![image](https://user-images.githubusercontent.com/45550579/149893881-de468cc6-314e-46a1-9f94-c9cabc538792.png)


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
